### PR TITLE
Update .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,7 +19,7 @@
           "@babel/preset-env",
           {
             "modules": false,
-            "corejs": 3,
+            "corejs": 2,
             "useBuiltIns": "usage"
           }
         ]


### PR DESCRIPTION
与依赖版本改为一致
"@babel/runtime-corejs2": "^7.16.0",