### PR TITLE
修复启动app时转义不全问题

### DIFF
--- a/src/core/app-search/darwin.ts
+++ b/src/core/app-search/darwin.ts
@@ -115,7 +115,7 @@ export default async (nativeImage: any) => {
       value: "plugin",
       desc: app.path,
       pluginType: "app",
-      action: `open ${app.path.replace(" ", "\\ ") as string}`,
+      action: `open ${app.path.replace(/ /g, "\\ ") as string}`,
       keyWords: [appSubStr],
     };
 


### PR DESCRIPTION
mac下启动的app名称超过1个空格，由于转义不全导致启动失败