### PR TITLE
bugfix: 修复mac环境下因对extract-file-icon的错误依赖导致的构建报错

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -9,6 +9,9 @@ module.exports = {
         "@": path.join(__dirname, "./src"),
       },
     },
+    externals: {
+      'extract-file-icon': 'commonjs extract-file-icon'
+    },
   },
   pages: {
     index: {


### PR DESCRIPTION
遇到了与issue相同的问题 #116  进行了定位和修复； 手头除mac外无其他设备；希望有条件的开发者验证win和linux下是否可以正常打包和运行 