### PR TITLE
Fix regex match error

### DIFF
--- a/src/renderer/plugins-manager/options.ts
+++ b/src/renderer/plugins-manager/options.ts
@@ -6,7 +6,7 @@ import useFocus from './clipboardWatch';
 
 function formatReg(regStr) {
   const flags = regStr.replace(/.*\/([gimy]*)$/, '$1');
-  const pattern = flags.replace(new RegExp('^/(.*?)/' + flags + '$'), '$1');
+  const pattern = regStr.replace(new RegExp('^/(.*?)/' + flags + '$'), '$1');
   return new RegExp(pattern, flags);
 }
 


### PR DESCRIPTION
```js

const regStr = '/abc-/gi';
const lists = [
    {
        type: 'regex',
        match: regStr
    }
]

console.log(searchKeyValues(lists, 'abc')) // should not match
console.log(searchKeyValues(lists, 'abc-')) // should match

```