### PR TITLE
修复 404 链接 /rubick/blob/master/static/preload.js#L49

### DIFF
--- a/docs/docs/dev/README.md
+++ b/docs/docs/dev/README.md
@@ -80,7 +80,7 @@ window.showNotification = function () {
   rubick.showNotification('HI, rubick')
 }
 ```
-rubick 更多支持 API 能力参考：[rubick 全局API](https://github.com/rubickCenter/rubick/blob/master/static/preload.js#L49)
+rubick 更多支持 API 能力参考：[rubick 全局API](https://github.com/rubickCenter/rubick/blob/master/public/preload.js)
 
 ### 测试写好的插件
 由于 `rubick` 插件是基于 `npm` 的管理方式，所以开发者调试插件，也是基于 `npm` 的软连接的方式进行调试。


### PR DESCRIPTION
rubick 全局API https://github.com/rubickCenter/rubick/blob/master/static/preload.js#L49 无法访问，搜索了项目中 preload.js 的位置，并进行了更新。